### PR TITLE
Maintain login status across tabs

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -192,7 +192,8 @@ import { PageUpdateProfileComponent } from './page-update-profile/page-update-pr
   // Refer to example in https://itnext.io/angular-create-your-own-modal-boxes-20bb663084a1
   entryComponents: [PageLoginComponent, PageRegisterComponent, PageUpdateProfileComponent],
   bootstrap: [ AppComponent ],
-  providers: [TransactionService, SearchService, CalEventService, AuthService, ModalService, DomService, httpInterceptorProviders]
+  providers: [ TransactionService, { provide: 'Window', useValue: window }, SearchService, CalEventService, AuthService, 
+                ModalService, DomService, httpInterceptorProviders]
 })
 export class AppModule {
   

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -102,10 +102,21 @@ export class AuthService {
            tap<LoginResultModel>( // Log the result or error
                 res => {
                           self.saveToken(res.user.token);
-                          // broadcast change in status to current tab
-                          self.loginStatus.next();
+                  
+                          // The following was noted at this link 
+                          // https://stackoverflow.com/questions/5370784/localstorage-eventlistener-is-not-called
+                          // The storage event handler will only affect other windows. Whenever something changes in 
+                          // one window inside localStorage all the other windows are notified about it and if any action
+                          // needs to be taken it can be achieved by a handler function listening to the storage event.
+                          //
+                          // For the same window you have to manually call the storageEventHandler function after 
+                          // localStorage.setItem() is called to achieve the same behaviour in the same window.
+                          
                           // broadcast change in status to other tabs
                           localStorage.setItem('login-event', 'login' + Math.random());
+
+                          // broadcast change in status to current tab
+                          self.loginStatus.next();
                        },         
                 error => console.log("failure after post "+ error.message)
               ),
@@ -199,10 +210,21 @@ export class AuthService {
            tap<LoginResultModel>( // Log the result or error
                 res => {
                           self.saveToken(res.user.token);
-                          // broadcast change in status to current tab
-                          self.loginStatus.next();
+                  
+                          // The following was noted at this link 
+                          // https://stackoverflow.com/questions/5370784/localstorage-eventlistener-is-not-called
+                          // The storage event handler will only affect other windows. Whenever something changes in 
+                          // one window inside localStorage all the other windows are notified about it and if any action
+                          // needs to be taken it can be achieved by a handler function listening to the storage event.
+                          //
+                          // For the same window you have to manually call the storageEventHandler function after 
+                          // localStorage.setItem() is called to achieve the same behaviour in the same window.
+                          
                           // broadcast change in status to other tabs
                           localStorage.setItem('login-event', 'login' + Math.random());
+
+                          // broadcast change in status to current tab
+                          self.loginStatus.next();
                        },        
                 error => console.log("failure after post "+ error.message)
               ),
@@ -212,7 +234,21 @@ export class AuthService {
   
   logout () {
       localStorage.removeItem("tob_id_token");
+    
+      // The following was noted at this link 
+      // https://stackoverflow.com/questions/5370784/localstorage-eventlistener-is-not-called
+      // The storage event handler will only affect other windows. Whenever something changes in 
+      // one window inside localStorage all the other windows are notified about it and if any action
+      // needs to be taken it can be achieved by a handler function listening to the storage event.
+      //
+      // For the same window you have to manually call the storageEventHandler function after 
+      // localStorage.setItem() is called to achieve the same behaviour in the same window.
+                          
+      // broadcast change in status to other tabs
       localStorage.setItem('logout-event', 'logout' + Math.random());
+
+      // broadcast change in status to current tab
+      self.loginStatus.next();
   }
   
   // the handler is self contained and is passed in the authentication service ... i.e, this object

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -248,7 +248,7 @@ export class AuthService {
       localStorage.setItem('logout-event', 'logout' + Math.random());
 
       // broadcast change in status to current tab
-      self.loginStatus.next();
+      this.loginStatus.next();
   }
   
   // the handler is self contained and is passed in the authentication service ... i.e, this object

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -102,8 +102,10 @@ export class AuthService {
            tap<LoginResultModel>( // Log the result or error
                 res => {
                           self.saveToken(res.user.token);
-                          // broadcast change in status
+                          // broadcast change in status to current tab
                           self.loginStatus.next();
+                          // broadcast change in status to other tabs
+                          localStorage.setItem('login-event', 'login' + Math.random());
                        },         
                 error => console.log("failure after post "+ error.message)
               ),
@@ -197,8 +199,10 @@ export class AuthService {
            tap<LoginResultModel>( // Log the result or error
                 res => {
                           self.saveToken(res.user.token);
-                          // broadcast change in status
+                          // broadcast change in status to current tab
                           self.loginStatus.next();
+                          // broadcast change in status to other tabs
+                          localStorage.setItem('login-event', 'login' + Math.random());
                        },        
                 error => console.log("failure after post "+ error.message)
               ),
@@ -221,6 +225,18 @@ export class AuthService {
      return function curried_func(event) {        
         if (event.key == 'logout-event') { 
           // console.log("hit logout handler")
+          authService.loginStatus.next();
+        }
+     }      
+  }
+  
+  // the primary purpose of this handler is to detect logins across tabs.  So if a user logs in on any
+  // active tab, the display on all other tabs will be refreshed to indicate this new status.
+  handleLoginEvent = function(authService) {
+     // return a function that would actually handle the login event
+     return function curried_func(event) {        
+        if (event.key == 'login-event') { 
+          // console.log("hit login handler")
           authService.loginStatus.next();
         }
      }      

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -208,7 +208,22 @@ export class AuthService {
   
   logout () {
       localStorage.removeItem("tob_id_token");
-      this.loginStatus.next();
+      localStorage.setItem('logout-event', 'logout' + Math.random());
+  }
+  
+  // the handler is self contained and is passed in the authentication service ... i.e, this object
+  // as authService
+  
+  // the primary purpose of this handler is to detect logouts across tabs.  So if a user logs out on any
+  // active tab, the display on all other tabs will be refreshed to indicate this new status.
+  handleLogoutEvent = function(authService) {
+     // return a function that would actually handle the logout event
+     return function curried_func(event) {        
+        if (event.key == 'logout-event') { 
+          // console.log("hit logout handler")
+          authService.loginStatus.next();
+        }
+     }      
   }
          
 }

--- a/src/app/calendar-editable/calendar-editable.component.ts
+++ b/src/app/calendar-editable/calendar-editable.component.ts
@@ -1,3 +1,4 @@
+// import { EventManager } from '@angular/platform-browser'; -- investigate using eventManager to manage changes to login status
 import { Component, OnInit, TemplateRef, ViewChild, Inject, LOCALE_ID } from '@angular/core';
 import { formatDate } from '@angular/common';
 import { HttpClient, HttpParams } from '@angular/common/http';
@@ -200,7 +201,7 @@ export class MyCalendarEditableComponent implements OnInit {
     
   private events$: CalendarEvent[];
 
-  constructor(private calEventService: CalEventService, private authService: AuthService, 
+  constructor(private calEventService: CalEventService, private authService: AuthService, @Inject('Window') private window: Window,
                private modalService: BsModalService, private http: HttpClient, @Inject(LOCALE_ID) private locale: string) {}
 
   private openModal(template: TemplateRef<any>) {
@@ -208,8 +209,11 @@ export class MyCalendarEditableComponent implements OnInit {
     this.modalRef = this.modalService.show(template);
   }
 
+  private logoutHandler = this.authService.handleLogoutEvent(this.authService);
+  
   ngOnInit() {
     /*this.fetchEvents();*/
+    window.addEventListener('storage', this.logoutHandler);
     this.loadColorSchemes();
     this.getCalendarEvents();
     // Schedule a refresh of the display if the user logs in or logs out
@@ -233,6 +237,7 @@ export class MyCalendarEditableComponent implements OnInit {
   }
   
   ngOnDestroy(): void {
+    window.removeEventListener('storage', this.logoutHandler);
     if (this.loginStatusSubscription) {
       this.loginStatusSubscription.unsubscribe();
     }

--- a/src/app/calendar-editable/calendar-editable.component.ts
+++ b/src/app/calendar-editable/calendar-editable.component.ts
@@ -447,7 +447,7 @@ export class MyCalendarEditableComponent implements OnInit {
         title: cevent.title,
         meta: {}
       };
-      if (this.authService.isLoggedIn()&&cevent.owner==this.authService.currentUser().user.id) {
+      if (this.authService.isLoggedIn()&&cevent.owner==this.authService.authPayload.id) {
         result.actions=this.actionsLoggedIn;
         // Only allow the event to be dragged or resized if the currently logged in user
         // owns the event
@@ -511,7 +511,7 @@ export class MyCalendarEditableComponent implements OnInit {
   
   private getColorSchemes(): void {
     let self=this;
-    let myId=this.authService.isLoggedIn() ? this.authService.currentUser().user.id : null;
+    let myId=this.authService.isLoggedIn() ? this.authService.authPayload.id : null;
     this.calEventService.getColorSchemes(myId)
     .subscribe(colorSchemes => {
                                   self.colorSchemes = colorSchemes;

--- a/src/app/calendar-editable/calendar-editable.component.ts
+++ b/src/app/calendar-editable/calendar-editable.component.ts
@@ -210,10 +210,12 @@ export class MyCalendarEditableComponent implements OnInit {
   }
 
   private logoutHandler = this.authService.handleLogoutEvent(this.authService);
+  private loginHandler = this.authService.handleLoginEvent(this.authService);
   
   ngOnInit() {
     /*this.fetchEvents();*/
     window.addEventListener('storage', this.logoutHandler);
+    window.addEventListener('storage', this.loginHandler);
     this.loadColorSchemes();
     this.getCalendarEvents();
     // Schedule a refresh of the display if the user logs in or logs out
@@ -238,6 +240,7 @@ export class MyCalendarEditableComponent implements OnInit {
   
   ngOnDestroy(): void {
     window.removeEventListener('storage', this.logoutHandler);
+    window.removeEventListener('storage', this.loginHandler);
     if (this.loginStatusSubscription) {
       this.loginStatusSubscription.unsubscribe();
     }

--- a/src/app/page-register/page-register.component.html
+++ b/src/app/page-register/page-register.component.html
@@ -20,10 +20,10 @@
         <div class="form-group">
           <br/>
           <!--
-          <label for="name">Full name</label>
+          <label for="name">User name</label>
           -->
-          <input type="text" class="form-control" id="name" placeholder="Enter your name" 
-                 [(ngModel)]="credentials.user.username" name="fullname">
+          <input type="text" class="form-control" id="name" placeholder="Enter user name" 
+                 [(ngModel)]="credentials.user.username" name="username">
         </div>
          
         <div class="form-group">

--- a/src/app/page-update-profile/page-update-profile.component.html
+++ b/src/app/page-update-profile/page-update-profile.component.html
@@ -20,9 +20,9 @@
         <div role="alert" [hidden]="formError==''" class="alert alert-danger">{{ formError }}</div>
         <div role="alert" [hidden]="formInfo==''" class="alert alert-info">{{ formInfo }}</div>
         <div class="form-group">
-          <label for="name">Full name</label>
-          <input type="text" class="form-control" id="name" placeholder="Enter your name" 
-                 [(ngModel)]="credentials.user.username" name="fullname">
+          <label for="name">User name</label>
+          <input type="text" class="form-control" id="name" placeholder="Enter user name" 
+                 [(ngModel)]="credentials.user.username" name="username">
         </div>
         <div class="form-group">
           <label for="bio">Bio</label>

--- a/src/app/tool-bar-scalable/tool-bar-scalable.component.html
+++ b/src/app/tool-bar-scalable/tool-bar-scalable.component.html
@@ -115,7 +115,7 @@
           <!-- User profile button -->
           <a dropdownToggle mdbWavesEffect type="button" class="nav-link dropdown-toggle btn-dark" 
               aria-controls="dropdown-nested-user">
-            {{authService.currentUser()?.user.name}}<span class="caret"></span>
+            {{authService.authPayload?.username}}<span class="caret"></span>
           </a>
            
           <!-- Nested dropdown associated with user profile button -->


### PR DESCRIPTION
Logout/Login events are communicated across tabs using window event listeners.

Event listener added for logout event using window.addEventListener('storage', this.logoutHandler);
This is triggered by logout where the following is done in the authService logout routine localStorage.removeItem('logout-event');

Something similar is done for login (or register or profile update) but the event is triggered by
localStorage.setItem('login-event', 'login' + Math.random());

Additionally, needed to inject the window object.  app.module.ts is updated to supply a provider for the Window class using the "window" object.  This object is injected in the calendar editable component so that the listeners could be added to it.

Finally, cleanup is done in terms of processing the authentication token.  Now it is only parsed if it changes and a copy of the attributes of the logged in user is maintained locally in authService in authPayload field.  Now if the attributes of the current user needs to be referenced, this field is referenced directly instead of calling the currentUser() function of authService.  In fact, currentUser() is no longer needed and is commented out.
